### PR TITLE
Add AvalynxSelect field to examples and enhance validation feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here's a simple example of how to use AvalynxForm in your project:
 * [Overview](https://avalynx-form.jbs-newmedia.de/examples/index.html)
 * [Form](https://avalynx-form.jbs-newmedia.de/examples/form.html)
 * [Form with slow response](https://avalynx-form.jbs-newmedia.de/examples/form-slow-response.html)
+* [Form with AvalynxSelect](https://avalynx-form.jbs-newmedia.de/examples/form-with-avalynx-select.html)
 
 ## Installation
 
@@ -41,7 +42,7 @@ Replace `path/to/avalynx-form.js` with the actual path to the file in your proje
 AvalynxForm is also available via [jsDelivr](https://www.jsdelivr.com/). You can include it in your project like this:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/avalynx-form@1.0.0/dist/js/avalynx-form.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/avalynx-form@1.0.1/dist/js/avalynx-form.js"></script>
 ```
 
 Make sure to also include Bootstrap's JS/CSS in your project to ensure AvalynxForm displays correctly.

--- a/__tests__/avalynx-form.test.js
+++ b/__tests__/avalynx-form.test.js
@@ -1,65 +1,647 @@
-import { AvalynxForm } from '../dist/js/avalynx-form.esm.js';
+/**
+ * AvalynxForm Jest Tests
+ * Comprehensive test suite for all important functionality
+ */
+
+// Mock bootstrap dropdown
+global.bootstrap = {
+    Dropdown: jest.fn().mockImplementation(() => ({
+        hide: jest.fn(),
+        show: jest.fn()
+    }))
+};
+
+const AvalynxForm = require('../src/js/avalynx-form.js');
 
 describe('AvalynxForm', () => {
-    let form;
-    let avalynxForm;
+    let formElement;
+    let consoleErrorSpy;
 
     beforeEach(() => {
-        form = document.createElement('form');
-        form.id = 'test-form';
-        form.action = '/submit';
-        form.method = 'POST';
-        form.innerHTML = `
-            <div class="form-group">
-                <input type="text" id="input1" name="input1" class="form-control" required>
-                <div class="invalid-feedback">Please provide a valid input.</div>
-            </div>
-            <button type="submit">Submit</button>
+        // Setup DOM
+        document.body.innerHTML = `
+            <form id="test-form" action="/api/submit" method="POST">
+                <div class="form-group">
+                    <input type="text" id="username" name="username" class="form-control" />
+                    <span class="invalid-feedback"></span>
+                </div>
+                <div class="form-group">
+                    <input type="email" id="email" name="email" class="form-control" />
+                    <span class="invalid-feedback"></span>
+                </div>
+                <div class="form-group">
+                    <input type="checkbox" name="terms" value="1" class="form-check-input" />
+                    <span class="invalid-feedback"></span>
+                </div>
+                <button type="submit">Submit</button>
+            </form>
         `;
-        document.body.appendChild(form);
+        formElement = document.getElementById('test-form');
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-        avalynxForm = new AvalynxForm('test-form', {
-            apiParams: { extraParam: 'extraValue' },
-            onSuccess: jest.fn(),
-            onError: jest.fn(),
-        });
+        // Mock fetch globally
+        global.fetch = jest.fn();
     });
 
     afterEach(() => {
-        document.body.removeChild(form);
+        consoleErrorSpy.mockRestore();
+        jest.clearAllMocks();
     });
 
-    test('should be created correctly', () => {
-        expect(avalynxForm).toBeInstanceOf(AvalynxForm);
+    describe('Constructor', () => {
+        test('should initialize with valid form ID', () => {
+            const form = new AvalynxForm('test-form');
+            expect(form.form).toBe(formElement);
+            expect(form.id).toBe('test-form');
+        });
+
+        test('should log error and return when form element not found', () => {
+            const form = new AvalynxForm('non-existent-form');
+            expect(consoleErrorSpy).toHaveBeenCalledWith("AvalynxForm: Element with id 'non-existent-form' not found");
+            expect(form.form).toBeNull();
+        });
+
+        test('should set default options', () => {
+            const form = new AvalynxForm('test-form');
+            expect(form.options.apiParams).toEqual({});
+            expect(form.options.loader).toBeNull();
+            expect(form.options.onSuccess).toBeNull();
+            expect(form.options.onError).toBeNull();
+        });
+
+        test('should merge custom options with defaults', () => {
+            const onSuccess = jest.fn();
+            const onError = jest.fn();
+            const apiParams = { test: 'value' };
+            const form = new AvalynxForm('test-form', {
+                apiParams,
+                onSuccess,
+                onError
+            });
+            expect(form.options.apiParams).toEqual(apiParams);
+            expect(form.options.onSuccess).toBe(onSuccess);
+            expect(form.options.onError).toBe(onError);
+        });
     });
 
-    test('init should set up the submit handler', () => {
-        const submitHandler = jest.spyOn(avalynxForm, 'setupSubmitHandler');
-        avalynxForm.init();
-        expect(submitHandler).toHaveBeenCalled();
+    describe('Initialization', () => {
+        test('should setup submit handler on init', () => {
+            const addEventListenerSpy = jest.spyOn(formElement, 'addEventListener');
+            new AvalynxForm('test-form');
+            expect(addEventListenerSpy).toHaveBeenCalledWith('submit', expect.any(Function));
+        });
+
+        test('should create overlay and loader when loader option is null', () => {
+            new AvalynxForm('test-form');
+            const overlay = document.getElementById('test-form-overlay');
+            expect(overlay).not.toBeNull();
+            expect(overlay.style.position).toBe('absolute');
+            expect(overlay.style.display).toBe('none');
+            expect(formElement.style.position).toBe('relative');
+        });
+
+        test('should not create overlay when custom loader is provided', () => {
+            const mockLoader = { load: false };
+            new AvalynxForm('test-form', { loader: mockLoader });
+            const overlay = document.getElementById('test-form-overlay');
+            expect(overlay).toBeNull();
+        });
+
+        test('should create spinner inside overlay', () => {
+            new AvalynxForm('test-form');
+            const overlay = document.getElementById('test-form-overlay');
+            const spinner = overlay.querySelector('.spinner-border');
+            expect(spinner).not.toBeNull();
+            expect(spinner.className).toContain('spinner-border');
+            expect(spinner.className).toContain('text-primary');
+        });
     });
 
-    test('showInvalidFeedback should display error messages', () => {
-        avalynxForm.showInvalidFeedback('input1', 'Invalid input');
-        const inputElement = form.querySelector('#input1');
-        expect(inputElement.classList).toContain('is-invalid');
-        const feedbackElement = inputElement.nextElementSibling;
-        expect(feedbackElement.style.display).toBe('block');
-        expect(feedbackElement.innerHTML).toBe('Invalid input');
+    describe('Form Submission', () => {
+        test('should prevent default form submission', () => {
+            const form = new AvalynxForm('test-form');
+            const event = new Event('submit', { bubbles: true, cancelable: true });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            formElement.dispatchEvent(event);
+            expect(preventDefaultSpy).toHaveBeenCalled();
+        });
+
+        test('should call sendAjaxRequest on form submit', async () => {
+            const form = new AvalynxForm('test-form');
+            const sendAjaxRequestSpy = jest.spyOn(form, 'sendAjaxRequest').mockResolvedValue();
+
+            const event = new Event('submit', { bubbles: true, cancelable: true });
+            formElement.dispatchEvent(event);
+
+            expect(sendAjaxRequestSpy).toHaveBeenCalled();
+        });
     });
 
-    test('clearInvalidFeedback should clear error messages', () => {
-        avalynxForm.showInvalidFeedback('input1', 'Invalid input');
-        avalynxForm.clearInvalidFeedback('input1');
-        const inputElement = form.querySelector('#input1');
-        expect(inputElement.classList).not.toContain('is-invalid');
-        const feedbackElement = inputElement.nextElementSibling;
-        expect(feedbackElement.style.display).toBe('none');
+    describe('AJAX Request Handling', () => {
+        test('should send FormData with correct action and method', async () => {
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            const form = new AvalynxForm('test-form');
+            await form.sendAjaxRequest();
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                'https://jestjs.io/api/submit',
+                expect.objectContaining({
+                    method: 'POST',
+                    body: expect.any(FormData)
+                })
+            );
+        });
+
+        test('should append apiParams to FormData', async () => {
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            const form = new AvalynxForm('test-form', {
+                apiParams: { api_key: '12345', token: 'abc' }
+            });
+
+            await form.sendAjaxRequest();
+
+            const callArgs = global.fetch.mock.calls[0];
+            const formData = callArgs[1].body;
+            expect(formData.get('api_key')).toBe('12345');
+            expect(formData.get('token')).toBe('abc');
+        });
+
+        test('should show overlay during request when no custom loader', async () => {
+            let resolvePromise;
+            global.fetch.mockReturnValue(new Promise(resolve => {
+                resolvePromise = resolve;
+            }));
+
+            const form = new AvalynxForm('test-form');
+            const overlay = document.getElementById('test-form-overlay');
+
+            const requestPromise = form.sendAjaxRequest();
+
+            // Check overlay is shown
+            expect(overlay.style.display).toBe('flex');
+
+            // Resolve the fetch
+            resolvePromise({ json: async () => ({ success: true }) });
+            await requestPromise;
+
+            // Check overlay is hidden
+            expect(overlay.style.display).toBe('none');
+        });
+
+        test('should use custom loader when provided', async () => {
+            let resolvePromise;
+            global.fetch.mockReturnValue(new Promise(resolve => {
+                resolvePromise = resolve;
+            }));
+
+            const mockLoader = { load: false };
+            const form = new AvalynxForm('test-form', { loader: mockLoader });
+
+            const requestPromise = form.sendAjaxRequest();
+
+            // Check loader is set to true
+            expect(mockLoader.load).toBe(true);
+
+            // Resolve the fetch
+            resolvePromise({ json: async () => ({ success: true }) });
+            await requestPromise;
+
+            // Check loader is set to false
+            expect(mockLoader.load).toBe(false);
+        });
+
+        test('should handle fetch errors gracefully', async () => {
+            const consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+            global.fetch.mockRejectedValue(new Error('Network error'));
+
+            const form = new AvalynxForm('test-form');
+            await form.sendAjaxRequest();
+
+            expect(consoleErrorMock).toHaveBeenCalledWith('Error during AJAX request:', expect.any(Error));
+
+            // Overlay should still be hidden after error
+            const overlay = document.getElementById('test-form-overlay');
+            expect(overlay.style.display).toBe('none');
+
+            consoleErrorMock.mockRestore();
+        });
+
+        test('should hide overlay even when overlay is null in finally block', async () => {
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            const form = new AvalynxForm('test-form');
+            const overlay = document.getElementById('test-form-overlay');
+            overlay.remove(); // Remove overlay to test null check
+
+            await expect(form.sendAjaxRequest()).resolves.not.toThrow();
+        });
     });
 
-    test('setupOverlayAndLoader should create overlay if loader is null', () => {
-        const overlay = document.getElementById('test-form-overlay');
-        expect(overlay).not.toBeNull();
-        expect(overlay.style.display).toBe('none');
+    describe('Response Handling', () => {
+        test('should call onSuccess callback on successful response', () => {
+            const onSuccess = jest.fn();
+            const form = new AvalynxForm('test-form', { onSuccess });
+
+            const response = { success: true, message: 'Form submitted' };
+            form.handleResponse(response);
+
+            expect(onSuccess).toHaveBeenCalledWith(response);
+        });
+
+        test('should redirect on successful response with redirect URL', () => {
+            delete window.location;
+            window.location = { href: '' };
+
+            const form = new AvalynxForm('test-form');
+            const response = { success: true, redirect: '/thank-you' };
+            form.handleResponse(response);
+
+            expect(window.location.href).toBe('/thank-you');
+        });
+
+        test('should show alert for debug messages', () => {
+            const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+            const form = new AvalynxForm('test-form');
+
+            const response = { debug_msg: 'Debug information', success: false };
+            form.handleResponse(response);
+
+            expect(alertSpy).toHaveBeenCalledWith('Debug information');
+            alertSpy.mockRestore();
+        });
+
+        test('should call onError callback on failed response', () => {
+            const onError = jest.fn();
+            const form = new AvalynxForm('test-form', { onError });
+
+            const response = { success: false, message: 'Validation failed' };
+            form.handleResponse(response);
+
+            expect(onError).toHaveBeenCalledWith(response);
+        });
+
+        test('should not call onSuccess when success is undefined', () => {
+            const onSuccess = jest.fn();
+            const form = new AvalynxForm('test-form', { onSuccess });
+
+            const response = { message: 'Some message' };
+            form.handleResponse(response);
+
+            expect(onSuccess).not.toHaveBeenCalled();
+        });
+
+        test('should not call onSuccess when success is false', () => {
+            const onSuccess = jest.fn();
+            const form = new AvalynxForm('test-form', { onSuccess });
+
+            const response = { success: false };
+            form.handleResponse(response);
+
+            expect(onSuccess).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Validation Feedback', () => {
+        test('should show invalid feedback for field', () => {
+            const form = new AvalynxForm('test-form');
+            const usernameInput = document.getElementById('username');
+            const feedbackElement = usernameInput.parentElement.querySelector('.invalid-feedback');
+
+            form.showInvalidFeedback('username', 'Username is required');
+
+            expect(usernameInput.classList.contains('is-invalid')).toBe(true);
+            expect(feedbackElement.innerHTML).toBe('Username is required');
+            expect(feedbackElement.style.display).toBe('block');
+        });
+
+        test('should show invalid feedback for field with name attribute', () => {
+            const form = new AvalynxForm('test-form');
+            const emailInput = document.querySelector('[name="email"]');
+            const feedbackElement = emailInput.parentElement.querySelector('.invalid-feedback');
+
+            form.showInvalidFeedback('email', 'Invalid email format');
+
+            expect(emailInput.classList.contains('is-invalid')).toBe(true);
+            expect(feedbackElement.innerHTML).toBe('Invalid email format');
+            expect(feedbackElement.style.display).toBe('block');
+        });
+
+        test('should handle multiple invalid fields from response', () => {
+            const form = new AvalynxForm('test-form');
+            const response = {
+                success: false,
+                invalid: {
+                    username: 'Username is required',
+                    email: 'Email is invalid'
+                }
+            };
+
+            form.handleResponse(response);
+
+            const usernameInput = document.getElementById('username');
+            const emailInput = document.getElementById('email');
+
+            expect(usernameInput.classList.contains('is-invalid')).toBe(true);
+            expect(emailInput.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should clear invalid feedback for field', () => {
+            const form = new AvalynxForm('test-form');
+            const usernameInput = document.getElementById('username');
+            const feedbackElement = usernameInput.parentElement.querySelector('.invalid-feedback');
+
+            // First add invalid feedback
+            form.showInvalidFeedback('username', 'Username is required');
+
+            // Then clear it
+            form.clearInvalidFeedback('username');
+
+            expect(usernameInput.classList.contains('is-invalid')).toBe(false);
+            expect(feedbackElement.innerHTML).toBe('&nbsp;');
+            expect(feedbackElement.style.display).toBe('none');
+        });
+
+        test('should clear valid fields from response', () => {
+            const form = new AvalynxForm('test-form');
+            const usernameInput = document.getElementById('username');
+
+            // Add invalid feedback first
+            form.showInvalidFeedback('username', 'Username is required');
+
+            const response = {
+                success: false,
+                valid: {
+                    username: true
+                }
+            };
+
+            form.handleResponse(response);
+
+            expect(usernameInput.classList.contains('is-invalid')).toBe(false);
+        });
+
+        test('should handle fields with array notation name[]', () => {
+            document.body.innerHTML += `
+                <form id="array-form" action="/api/submit" method="POST">
+                    <div class="form-group">
+                        <input type="text" name="tags[]" class="form-control" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                </form>
+            `;
+
+            const form = new AvalynxForm('array-form');
+            form.showInvalidFeedback('tags', 'At least one tag is required');
+
+            const input = document.querySelector('[name="tags[]"]');
+            expect(input.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should handle fields with associative array notation name[key]', () => {
+            document.body.innerHTML += `
+                <form id="assoc-form" action="/api/submit" method="POST">
+                    <div class="form-group">
+                        <input type="text" name="user[name]" class="form-control" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                    <div class="form-group">
+                        <input type="text" name="user[email]" class="form-control" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                </form>
+            `;
+
+            const form = new AvalynxForm('assoc-form');
+            // The source code uses [name^="user["] selector which matches fields starting with "user["
+            form.showInvalidFeedback('user', 'User information is invalid');
+
+            const input1 = document.querySelector('[name="user[name]"]');
+            const input2 = document.querySelector('[name="user[email]"]');
+            expect(input1.classList.contains('is-invalid')).toBe(true);
+            expect(input2.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should handle fields without form-group parent', () => {
+            document.body.innerHTML += `
+                <form id="no-group-form" action="/api/submit" method="POST">
+                    <div>
+                        <input type="text" id="simple" name="simple" class="form-control" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                </form>
+            `;
+
+            const form = new AvalynxForm('no-group-form');
+            form.showInvalidFeedback('simple', 'Field is invalid');
+
+            const input = document.getElementById('simple');
+            expect(input.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should handle fields without invalid-feedback span', () => {
+            document.body.innerHTML += `
+                <form id="no-feedback-form" action="/api/submit" method="POST">
+                    <div class="form-group">
+                        <input type="text" id="nofeedback" name="nofeedback" class="form-control" />
+                    </div>
+                </form>
+            `;
+
+            const form = new AvalynxForm('no-feedback-form');
+            const input = document.getElementById('nofeedback');
+
+            // Should not throw error
+            expect(() => form.showInvalidFeedback('nofeedback', 'Error message')).not.toThrow();
+            expect(input.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should handle multiple elements with same name', () => {
+            document.body.innerHTML += `
+                <form id="multi-form" action="/api/submit" method="POST">
+                    <div class="form-group">
+                        <input type="checkbox" name="options" value="1" class="form-check-input" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                    <div class="form-group">
+                        <input type="checkbox" name="options" value="2" class="form-check-input" />
+                        <span class="invalid-feedback"></span>
+                    </div>
+                </form>
+            `;
+
+            const form = new AvalynxForm('multi-form');
+            form.showInvalidFeedback('options', 'Select at least one option');
+
+            const inputs = document.querySelectorAll('[name="options"]');
+            inputs.forEach(input => {
+                expect(input.classList.contains('is-invalid')).toBe(true);
+            });
+        });
+    });
+
+    describe('Integration Tests', () => {
+        test('should complete full submission flow with success', async () => {
+            const onSuccess = jest.fn();
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true, message: 'Saved successfully' })
+            });
+
+            const form = new AvalynxForm('test-form', { onSuccess });
+
+            const event = new Event('submit', { bubbles: true, cancelable: true });
+            formElement.dispatchEvent(event);
+
+            // Wait for async operations
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(global.fetch).toHaveBeenCalled();
+            expect(onSuccess).toHaveBeenCalledWith({ success: true, message: 'Saved successfully' });
+        });
+
+        test('should complete full submission flow with validation errors', async () => {
+            const onError = jest.fn();
+            global.fetch.mockResolvedValue({
+                json: async () => ({
+                    success: false,
+                    invalid: {
+                        username: 'Username is required',
+                        email: 'Email is invalid'
+                    }
+                })
+            });
+
+            const form = new AvalynxForm('test-form', { onError });
+
+            const event = new Event('submit', { bubbles: true, cancelable: true });
+            formElement.dispatchEvent(event);
+
+            // Wait for async operations
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            expect(global.fetch).toHaveBeenCalled();
+            expect(onError).toHaveBeenCalled();
+
+            const usernameInput = document.getElementById('username');
+            const emailInput = document.getElementById('email');
+            expect(usernameInput.classList.contains('is-invalid')).toBe(true);
+            expect(emailInput.classList.contains('is-invalid')).toBe(true);
+        });
+
+        test('should handle mixed valid and invalid fields', async () => {
+            const onError = jest.fn();
+            global.fetch.mockResolvedValue({
+                json: async () => ({
+                    success: false,
+                    valid: {
+                        email: true
+                    },
+                    invalid: {
+                        username: 'Username is required'
+                    }
+                })
+            });
+
+            const form = new AvalynxForm('test-form', { onError });
+
+            // First mark email as invalid
+            form.showInvalidFeedback('email', 'Some error');
+
+            const event = new Event('submit', { bubbles: true, cancelable: true });
+            formElement.dispatchEvent(event);
+
+            // Wait for async operations
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            const usernameInput = document.getElementById('username');
+            const emailInput = document.getElementById('email');
+            expect(usernameInput.classList.contains('is-invalid')).toBe(true);
+            expect(emailInput.classList.contains('is-invalid')).toBe(false);
+        });
+    });
+
+    describe('Edge Cases', () => {
+        test('should handle empty response object', () => {
+            const form = new AvalynxForm('test-form');
+            expect(() => form.handleResponse({})).not.toThrow();
+        });
+
+        test('should handle null response', () => {
+            const form = new AvalynxForm('test-form');
+            expect(() => form.handleResponse(null)).toThrow();
+        });
+
+        test('should handle form method in different cases', async () => {
+            formElement.method = 'post';
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            const form = new AvalynxForm('test-form');
+            await form.sendAjaxRequest();
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    method: 'POST'
+                })
+            );
+        });
+
+        test('should handle form with GET method', async () => {
+            formElement.method = 'GET';
+            global.fetch.mockResolvedValue({
+                json: async () => ({ success: true })
+            });
+
+            const form = new AvalynxForm('test-form');
+            await form.sendAjaxRequest();
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    method: 'GET'
+                })
+            );
+        });
+
+        test('should handle success: false without calling onError when onError is not provided', () => {
+            const form = new AvalynxForm('test-form');
+            expect(() => form.handleResponse({ success: false })).not.toThrow();
+        });
+
+        test('should handle both debug_msg and success redirect', () => {
+            const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+            delete window.location;
+            window.location = { href: '' };
+
+            const onSuccess = jest.fn();
+            const form = new AvalynxForm('test-form', { onSuccess });
+
+            const response = {
+                success: true,
+                debug_msg: 'Debug info',
+                redirect: '/success-page'
+            };
+            form.handleResponse(response);
+
+            expect(alertSpy).toHaveBeenCalledWith('Debug info');
+            expect(onSuccess).toHaveBeenCalledWith(response);
+            expect(window.location.href).toBe('/success-page');
+
+            alertSpy.mockRestore();
+        });
     });
 });

--- a/build.js
+++ b/build.js
@@ -18,7 +18,9 @@ fs.readFile(filePath, 'utf8', (err, data) => {
         return;
     }
 
-    const result = data.replace(/class /g, 'export class ');
+    let result = data.replace(/class AvalynxForm /g, 'import * as bootstrap from \'bootstrap\';\n\nexport class AvalynxForm ');
+
+    result = result.replace(/\n\nif \(typeof module !== 'undefined' && module\.exports\) \{\n    module\.exports = AvalynxForm;\n\}\n?$/, '');
 
     fs.writeFile(filePath, result, 'utf8', err => {
         if (err) {

--- a/dist/js/avalynx-form.esm.js
+++ b/dist/js/avalynx-form.esm.js
@@ -19,6 +19,8 @@
  *
  */
 
+import * as bootstrap from 'bootstrap';
+
 export class AvalynxForm {
     constructor(id, options = {}) {
         this.form = document.getElementById(id);
@@ -120,7 +122,7 @@ export class AvalynxForm {
     }
 
     showInvalidFeedback(key, value) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {
@@ -135,7 +137,7 @@ export class AvalynxForm {
     }
 
     clearInvalidFeedback(key) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {

--- a/dist/js/avalynx-form.js
+++ b/dist/js/avalynx-form.js
@@ -120,7 +120,7 @@ class AvalynxForm {
     }
 
     showInvalidFeedback(key, value) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {
@@ -135,7 +135,7 @@ class AvalynxForm {
     }
 
     clearInvalidFeedback(key) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {
@@ -174,4 +174,8 @@ class AvalynxForm {
             this.form.appendChild(overlay);
         }
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = AvalynxForm;
 }

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,21 @@
-FROM webdevops/php-apache-dev:8.1
+FROM webdevops/php-apache-dev:8.3
 
 # Update and install
 RUN apt-get update && apt-get install -y
+
+#Nano
+RUN apt-get install -y nano
+
+#Keyring
+RUN mkdir -p /etc/apt/keyrings
+
+# Node.js
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN NODE_MAJOR=18 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+# Yarn
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor |  tee /usr/share/keyrings/yarnkey.gpg >/dev/null 2>&1
+RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" |  tee /etc/apt/sources.list.d/yarn.list >/dev/null 2>&1
+RUN apt-get update && apt-get install -y yarn
+
+USER application

--- a/examples/form-avalynx-select.html
+++ b/examples/form-avalynx-select.html
@@ -19,6 +19,9 @@
     <!-- AvalynxForm 1.0.1 -->
     <script src="https://cdn.jsdelivr.net/npm/avalynx-form@1.0.1/dist/js/avalynx-form.min.js"></script>
 
+    <!-- AvalynxSelect 1.1.0 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-select@1.1.0/dist/js/avalynx-select.min.js"></script>
+
     <!-- Example helper -->
     <link href="./css/helper.css" rel="stylesheet">
     <script src="./js/helper.js"></script>
@@ -38,7 +41,7 @@
     <br/>
     <br/>
     <div class="alert alert-info">
-        This is an example of the AvalynxForm. It is a simple form with some fields. The form validation is fetched from a PHP script.
+        This is an example of the AvalynxForm. It is a simple form with some fields and an AvalynxSelect field. The form validation is fetched from a PHP script.
     </div>
 
     <form id="form_validation" action="php/result.php" method="POST">
@@ -49,6 +52,21 @@
                 <option value="">Please select...</option>
                 <option value="ms">Ms.</option>
                 <option value="mr">Mr.</option>
+            </select>
+            <span class="invalid-feedback"></span>
+        </div>
+
+        <div class="form-group mb-3">
+            <label class="form-label" for="avalynxselect">Person (with AvalynxSelect):</label>
+            <select class="form-select avalynx-select" name="avalynxselect" id="avalynxselect">
+                <option value="">Select a person</option>
+                <option value="1">Thomas Fischer</option>
+                <option value="2">John Doe</option>
+                <option value="3">Jane Doe</option>
+                <option value="4">Max Mustermann</option>
+                <option value="5">Erika Mustermann</option>
+                <option value="6">Hans Müller</option>
+                <option value="7">Anna Müller</option>
             </select>
             <span class="invalid-feedback"></span>
         </div>
@@ -118,6 +136,11 @@
     <script>
 
         document.addEventListener('DOMContentLoaded', () => {
+            const avalynxSelect = new AvalynxSelect('#avalynxselect', {
+                scrollItems: 5,
+                liveSearch: true
+            });
+
             const form = new AvalynxForm('form_validation', {
                 apiParams: {key1: 'value1', key2: 'value2'},
                 onSuccess: (response) => {
@@ -136,6 +159,11 @@
     <h3>Source of example<a class="p-1 float-end btn btn-secondary btn-small" id="copyButton">Copy to clipboard</a></h3>
     <pre><code class="language-javascript" id="codeBlock">
 document.addEventListener('DOMContentLoaded', () => {
+    const avalynxSelect = new AvalynxSelect('#avalynxselect', {
+        scrollItems: 5,
+        liveSearch: true
+    });
+
     const form = new AvalynxForm('form_validation', {
         apiParams: {key1: 'value1', key2: 'value2'},
         onSuccess: (response) => {

--- a/examples/form-slow-response.html
+++ b/examples/form-slow-response.html
@@ -16,10 +16,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9/build/styles/stackoverflow-light.min.css" id="hljsTheme">
     <script>hljs.highlightAll();</script>
 
-    <script src="../src/js/avalynx-form.js"></script>
-
-    <!-- AvalynxForm 1.0.0 -->
-    <script src="https://cdn.jsdelivr.net/npm/avalynx-form@1.0.0/dist/js/avalynx-form.min.js"></script>
+    <!-- AvalynxForm 1.0.1 -->
+    <script src="https://cdn.jsdelivr.net/npm/avalynx-form@1.0.1/dist/js/avalynx-form.min.js"></script>
 
     <!-- Example helper -->
     <link href="./css/helper.css" rel="stylesheet">

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,6 +22,7 @@
 	<ul class="list-group py-3">
 		<li class="list-group-item"><a href="form.html">Form</a></li>
 		<li class="list-group-item"><a href="form-slow-response.html">Form with slow response</a></li>
+        <li class="list-group-item"><a href="form-avalynx-select.html">Form with AvalynxSelect</a></li>
 	</ul>
 
 	<a href="https://github.com/avalynx/avalynx-form" target="_blank" class="btn btn-primary">AvalynxForm on GitHub</a> <a href="https://github.com/avalynx/" target="_blank" class="btn btn-primary">Avalynx on GitHub</a>

--- a/examples/php/result.php
+++ b/examples/php/result.php
@@ -11,6 +11,7 @@ foreach (['customer_accept_terms', 'customer_newsletter', 'customer_hear_about']
 }
 
 $data['customer_form'] = (isset($_POST['customer_form']))?$_POST['customer_form']:'';
+$data['avalynxselect'] = (isset($_POST['avalynxselect']))?$_POST['avalynxselect']:'';
 $data['customer_title'] = (isset($_POST['customer_title']))?$_POST['customer_title']:'';
 $data['customer_firstname'] = (isset($_POST['customer_firstname']))?$_POST['customer_firstname']:'';
 $data['customer_lastname'] = (isset($_POST['customer_lastname']))?$_POST['customer_lastname']:'';
@@ -22,6 +23,12 @@ if (mb_strlen($data['customer_form']) === 0) {
     $json['invalid']['customer_form'] = 'Please select your form.';
 } elseif (in_array($data['customer_form'], ['mr', 'mrs'])) {
     $json['invalid']['customer_form'] = 'Please select a valid form.';
+}
+
+if (mb_strlen($data['avalynxselect']) === 0) {
+    $json['invalid']['avalynxselect'] = 'Please select your person.';
+} elseif (in_array($data['avalynxselect'], ['option1', 'option2', 'option3'])) {
+    $json['invalid']['avalynxselect'] = 'Please select a valid option.';
 }
 
 if (mb_strlen($data['customer_title']) === 0) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "avalynx-form",
   "title": "AvalynxForm",
   "description": "AvalynxForm is a lightweight, customizable form handling library for web applications. Based on Bootstrap >=5.3 without any framework dependencies.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "dist/js/avalynx-form.js",
   "module": "dist/js/avalynx-form.esm.js",

--- a/src/js/avalynx-form.js
+++ b/src/js/avalynx-form.js
@@ -3,7 +3,7 @@
  *
  * AvalynxForm is a lightweight, customizable form handling library for web applications. Based on Bootstrap >=5.3 without any framework dependencies.
  *
- * @version 1.0.0
+ * @version 1.0.1
  * @license MIT
  * @author https://github.com/avalynx/avalynx-datatable/graphs/contributors
  * @website https://github.com/avalynx/
@@ -120,7 +120,7 @@ class AvalynxForm {
     }
 
     showInvalidFeedback(key, value) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {
@@ -135,7 +135,7 @@ class AvalynxForm {
     }
 
     clearInvalidFeedback(key) {
-        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}["]`);
+        const elements = document.querySelectorAll(`#${key}, [name="${key}"], [name="${key}[]"], [name^="${key}\\["]`);
         elements.forEach(element => {
             const parentElement = element.closest('.form-group') || element.parentElement;
             if (parentElement !== null) {
@@ -174,4 +174,8 @@ class AvalynxForm {
             this.form.appendChild(overlay);
         }
     }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = AvalynxForm;
 }


### PR DESCRIPTION
- Introduced `avalynxselect` field in `result.php` with validation logic.
- Updated `avalynx-form.js` for improved feedback selector handling.
- Added `form-avalynx-select.html` example showcasing AvalynxSelect usage.
- Extended Jest tests for AvalynxForm to cover new validation and submission cases.
- Bumped AvalynxForm to version 1.0.1 across references.